### PR TITLE
keeper Prometheus metrics

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
 	"github.com/sorintlab/stolon/internal/util"
@@ -75,6 +76,24 @@ func AddCommonFlags(cmd *cobra.Command, cfg *CommonConfig) {
 	}
 }
 
+var (
+	// clusterIdentifier provides a Prometheus metric that should uniquely identify the
+	// cluster that any stolon component is associated with. Users can then join between
+	// various metric series for the same cluster without making assumptions about service
+	// discovery labels.
+	clusterIdentifier = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "stolon_cluster_identifier",
+			Help: "Set to 1, is labelled with store_prefix and cluster_name",
+		},
+		[]string{"store_prefix", "cluster_name"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(clusterIdentifier)
+}
+
 func CheckCommonConfig(cfg *CommonConfig) error {
 	if cfg.ClusterName == "" {
 		return fmt.Errorf("cluster name required")
@@ -102,6 +121,13 @@ func CheckCommonConfig(cfg *CommonConfig) error {
 	}
 
 	return nil
+}
+
+// SetMetrics should be called by any stolon component that outputs application metrics.
+// It sets the clusterIdentifier metric, which is key to joining across all the other
+// metric series.
+func SetMetrics(cfg *CommonConfig) {
+	clusterIdentifier.WithLabelValues(cfg.StorePrefix, cfg.ClusterName).Set(1)
 }
 
 func IsColorLoggerEnable(cmd *cobra.Command, cfg *CommonConfig) bool {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -42,6 +42,13 @@ const (
 	RoleStandby   Role = "standby"
 )
 
+// Roles enumerates all possible Role values
+var Roles = []Role{
+	RoleUndefined,
+	RoleMaster,
+	RoleStandby,
+}
+
 func UID() string {
 	u := uuid.NewV4()
 	return fmt.Sprintf("%x", u[:4])


### PR DESCRIPTION
Add a collection of Prometheus metrics to the keeper. The metrics are
aimed to expose errors in the keeper sync loop, providing enough
visibility to detect when the sync is failing (and some insight into
why).

---

This commit can be tested in the stolon-pgbouncer setup https://github.com/gocardless/stolon-pgbouncer/pull/29

<img width="925" alt="Screenshot 2019-04-30 at 16 58 23" src="https://user-images.githubusercontent.com/3518874/56975674-35cee380-6b69-11e9-822e-5058fbaff248.png">
