### PR TITLE
Change default pg_basebackup flags

### DIFF
--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -832,7 +832,7 @@ func (p *Manager) SyncFromFollowed(followedConnParams ConnParams, replSlot strin
 
 	log.Infow("running pg_basebackup")
 	name := filepath.Join(p.pgBinPath, "pg_basebackup")
-	args := []string{"-R", "-Xs", "-D", p.dataDir, "-d", followedConnString}
+	args := []string{"-R", "-Xs", "-c", "fast", "-P", "-v", "-D", p.dataDir, "-d", followedConnString}
 	if replSlot != "" {
 		args = append(args, "--slot", replSlot)
 	}


### PR DESCRIPTION
This PR changes the default pg_basebackup flags to use the following:

-c fast: Sets checkpoint mode to fast (immediate)
-P Enables progress reporting.
-v Enables verbose mode. Will output some extra steps during startup and shutdown, as well as show the exact file name that is currently being processed if progress reporting is also enabled.

I want to contribute this change upstream, but I reckon that those flags will require settings which might use cli flags for the keeper or new settings in the cluster data. I will open a new PR upstream next week for this, in the meanwhile we might want to give a try to these flags ourselves. 