### PR TITLE
Fix hanging sentinels

### DIFF
--- a/internal/store/etcdv3.go
+++ b/internal/store/etcdv3.go
@@ -195,9 +195,14 @@ func (e *etcdv3Election) campaign() {
 	defer close(e.electedCh)
 	defer close(e.errCh)
 
+	// Every resource in this campaign must be cleaned up as soon as we return. Failure to
+	// clean-up our session will cause all sentinels to hang.
+	ctx, cancel := context.WithCancel(e.ctx)
+	defer cancel()
+
 	for {
 		e.electedCh <- false
-		s, err := concurrency.NewSession(e.c, concurrency.WithTTL(int(e.ttl.Seconds())), concurrency.WithContext(e.ctx))
+		s, err := concurrency.NewSession(e.c, concurrency.WithTTL(int(e.ttl.Seconds())), concurrency.WithContext(ctx))
 		if err != nil {
 			e.running = false
 			e.errCh <- err
@@ -205,7 +210,16 @@ func (e *etcdv3Election) campaign() {
 		}
 
 		etcdElection := concurrency.NewElection(s, e.path)
-		if err = etcdElection.Campaign(e.ctx, e.candidateUID); err != nil {
+
+		// Campaign has the potential to block until the given ctx terminates. The design of
+		// leadership election means we'll wait until all existing keys with a creation prior
+		// to the current election term to be deleted. If other sentinels incorrectly persist
+		// their key leases then we could be here forever.
+		//
+		// For this reason, be extremely careful to terminate the previous election session.
+		// Failure to do so with lock-up every sentinel in the cluster with potentially
+		// terrible consequences.
+		if err = etcdElection.Campaign(ctx, e.candidateUID); err != nil {
 			e.running = false
 			e.errCh <- err
 			return
@@ -214,7 +228,7 @@ func (e *etcdv3Election) campaign() {
 		e.electedCh <- true
 
 		select {
-		case <-e.ctx.Done():
+		case <-ctx.Done():
 			e.running = false
 			etcdElection.Resign(context.TODO())
 			return


### PR DESCRIPTION
If etcd returned an error, our previous behaviour would be to report the
error and restart an election. The outer loop never responded to the
error by stopping the election, which would cancel the context, and
instead would restart a new campaign.

The first campaigns session will continue to exist on the context the
election loop had originally provided it, which is context.Background.
We'll come round to perform a new leadership election and the
etcdElection.Campaign() method will block waiting for all existing
leased keys to be removed from the prefix. Because the old campaign
sessions are still alive, they'll continue to renew their leases and
ensure those revisions never get deleted, thus blocking our sentinel
campaign loop indefinitely.

This change ensures we end our session whenever we return from the
campaign function which should ensure leased values can't persist beyond
the lifetime of our campaign. In future we should look to simplify this
election interface, as I have no confidence that we don't have other
bugs of a similar vein waiting to catch us.