### PR TITLE
Modify stolon-proxy and store timeout/interval

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -15,9 +15,16 @@
 package main
 
 import (
+	"os"
+
+	"github.com/coreos/etcd/clientv3"
 	"github.com/sorintlab/stolon/cmd/proxy/cmd"
+	"google.golang.org/grpc/grpclog"
 )
 
 func main() {
+	clientv3.SetLogger(
+		grpclog.NewLoggerV2WithVerbosity(os.Stderr, os.Stderr, os.Stderr, 0),
+	)
 	cmd.Execute()
 }

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -43,9 +43,9 @@ const (
 )
 
 const (
-	DefaultStoreTimeout         = 5 * time.Second
-	DefaultProxyCheckInterval   = 5 * time.Second
-	DefaultProxyTimeoutInterval = 15 * time.Second
+	DefaultStoreTimeout         = 3 * time.Second
+	DefaultProxyCheckInterval   = 3 * time.Second
+	DefaultProxyTimeoutInterval = 20 * time.Second
 
 	DefaultDBWaitReadyTimeout = 60 * time.Second
 


### PR DESCRIPTION
With a store timeout and proxy check interval of 5s, along with a proxy
timeout of 15s, we'll only have space to try two requests in the case of
an etcd node being unresponsive.

This is due to the first request taking 5s (store timeout) then us
waiting 5s before starting a second (check interval) and finally timing
out once again (store timeout) just a moment after our check timeout of
15s has triggered the proxy to sever connections.

With this change we should have time to perform four store operations
prior to the timeout kicking in, allowing the underlying etcd balancer
to have tried many different nodes before we kill all database
connections.