### PR TITLE
WIP: Allow for replica only keepers

### DIFF
--- a/cmd/stolonctl/cmd/status.go
+++ b/cmd/stolonctl/cmd/status.go
@@ -350,6 +350,8 @@ func getKeeperRoles(dbuid string, cd *cluster.ClusterData) map[string]string {
 			keeperRoles[dbuid] = "sync"
 		} else if isExternalSynchronousStandby(parentDbuid, dbuid, cd) {
 			keeperRoles[dbuid] = "external sync"
+		} else if cd.DBs[dbuid].Spec.Replica {
+			keeperRoles[dbuid] = "async replica"
 		} else {
 			keeperRoles[dbuid] = "async"
 		}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -549,7 +549,9 @@ func NewCluster(uid string, cs *ClusterSpec) *Cluster {
 	return c
 }
 
-type KeeperSpec struct{}
+type KeeperSpec struct {
+	Replica bool `json:"replica,omitempty"`
+}
 
 type KeeperStatus struct {
 	Healthy         bool      `json:"healthy,omitempty"`
@@ -578,7 +580,9 @@ func NewKeeperFromKeeperInfo(ki *KeeperInfo) *Keeper {
 		UID:        ki.UID,
 		Generation: InitialGeneration,
 		ChangeTime: time.Time{},
-		Spec:       &KeeperSpec{},
+		Spec: &KeeperSpec{
+			Replica: ki.Replica,
+		},
 		Status: KeeperStatus{
 			Healthy:         true,
 			LastHealthyTime: time.Now(),
@@ -637,6 +641,8 @@ type DBSpec struct {
 	SynchronousStandbys []string `json:"synchronousStandbys"`
 	// External SynchronousStandbys are external standbys names to be configured as synchronous
 	ExternalSynchronousStandbys []string `json:"externalSynchronousStandbys"`
+	// Replica only
+	Replica bool `json:"replica,omitempty"`
 }
 
 type DBStatus struct {

--- a/internal/cluster/member.go
+++ b/internal/cluster/member.go
@@ -50,6 +50,8 @@ type KeeperInfo struct {
 	PostgresBinaryVersion PostgresBinaryVersion `json:"postgresBinaryVersion,omitempty"`
 
 	PostgresState *PostgresState `json:"postgresState,omitempty"`
+
+	Replica bool `json:"replica,omitempty"`
 }
 
 func (k *KeeperInfo) DeepCopy() *KeeperInfo {


### PR DESCRIPTION
We want to be able to use replica only keepers that are never eligible
for master election or synchronous standby promotion.

We do this by adding a --replica flag to the keeper that is propagated to
the keeper spec and to the keepers db spec allowing us to filter out
these keepers/dbs during the initial master election and synchronous
standby promotion.

```
root@pgbouncer:/# stolonctl status
=== Active sentinels ===

ID              LEADER
19381aa3        true

=== Active proxies ===

ID
0afb513a
419ec962
59d37952
80edc6aa

=== Keepers ===

UID     HEALTHY PG LISTENADDRESS        PG HEALTHY      PG WANTEDGENERATION     PG CURRENTGENERATION
keeper0 true    172.26.0.7:5432         true            6                       6
keeper1 true    172.26.0.8:5432 true    3       3
keeper2 true    172.26.0.6:5432 true    8       8
keeper3 true    172.26.0.9:5432 true    9       9

=== Cluster Info ===

Master Keeper: keeper2

===== Keepers/DB tree =====

keeper2 (master)
└─keeper1 (sync)
  ├─keeper3 (async replica)
  └─keeper0 (async)
```