### PR TITLE
Prevent stolonctl init with empty file

### DIFF
--- a/cmd/stolonctl/cmd/init.go
+++ b/cmd/stolonctl/cmd/init.go
@@ -51,12 +51,15 @@ func initCluster(cmd *cobra.Command, args []string) {
 		die("too many arguments")
 	}
 
+	dataSupplied := false
 	data := []byte{}
 	switch len(args) {
 	case 1:
+		dataSupplied = true
 		data = []byte(args[0])
 	case 0:
 		if initOpts.file != "" {
+			dataSupplied = true
 			var err error
 			if initOpts.file == "-" {
 				data, err = ioutil.ReadAll(os.Stdin)
@@ -104,14 +107,14 @@ func initCluster(cmd *cobra.Command, args []string) {
 	}
 
 	var cs *cluster.ClusterSpec
-	if len(data) == 0 {
-		// Define a new cluster spec with initMode "new"
-		cs = &cluster.ClusterSpec{}
-		cs.InitMode = cluster.ClusterInitModeP(cluster.ClusterInitModeNew)
-	} else {
+	if dataSupplied {
 		if err := json.Unmarshal(data, &cs); err != nil {
 			die("failed to unmarshal cluster spec: %v", err)
 		}
+	} else {
+		// Define a new cluster spec with initMode "new"
+		cs = &cluster.ClusterSpec{}
+		cs.InitMode = cluster.ClusterInitModeP(cluster.ClusterInitModeNew)
 	}
 
 	if err := cs.Validate(); err != nil {


### PR DESCRIPTION
This fixes what is debatably a bug, where supplying the file flag to
`stolonctl init` with a value that points to an empty file results in
initialising the cluster with an `initMode` of `new`.

This behaviour is dangerous because if the user intended to supply a
file that contained a cluster specification with an `initMode` of
`existing`, but mistakenly supplied a path to an empty file, then it
would result in the keeper data being removed.

To resolve this, change the behaviour of the command to always attempt
the unmarshalling of the supplied cluster spec JSON, which will result
in a fatal error in the case of an empty file.

If the user intends to initialise the cluster with a blank (`initMode:
new`)
cluster specification then they should do so by omitting the file
flag and cluster specification argument, as is already possible.