### PR TITLE
Allow custom PostgreSQL node config

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -123,6 +123,17 @@ type config struct {
 	pgOverrideParameters []string
 }
 
+func (c *config) parsePgOverrideParameters() map[string]string {
+	m := make(map[string]string)
+
+	for _, e := range c.pgOverrideParameters {
+		s := strings.Split(e, "=")
+		m[s[0]] = s[1]
+	}
+
+	return m
+}
+
 var cfg config
 
 func init() {
@@ -472,6 +483,8 @@ type PostgresKeeper struct {
 
 	neverMaster             bool
 	neverSynchronousReplica bool
+
+	pgParameterOverride map[string]string
 }
 
 func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
@@ -515,6 +528,8 @@ func NewPostgresKeeper(cfg *config, end chan error) (*PostgresKeeper, error) {
 
 		neverMaster:             cfg.neverMaster,
 		neverSynchronousReplica: cfg.neverSynchronousReplica,
+
+		pgParameterOverride: cfg.parsePgOverrideParameters(),
 
 		e:   e,
 		end: end,

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -343,6 +343,11 @@ func (p *PostgresKeeper) createPGParameters(db *cluster.DB) common.Parameters {
 		parameters[k] = v
 	}
 
+	// Override parameters from those supplied to the keeper on boot
+	for k, v := range p.pgParameterOverride {
+		parameters[k] = v
+	}
+
 	parameters["listen_addresses"] = p.pgListenAddress
 
 	parameters["port"] = p.pgPort

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -119,6 +119,8 @@ type config struct {
 
 	neverMaster             bool
 	neverSynchronousReplica bool
+
+	pgOverrideParameters []string
 }
 
 var cfg config
@@ -148,10 +150,12 @@ func init() {
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgSUUsername, "pg-su-username", user, "postgres superuser user name. Used for keeper managed instance access and pg_rewind based synchronization. It'll be created on db initialization. Defaults to the name of the effective user running stolon-keeper. Must be the same for all keepers.")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgSUPassword, "pg-su-password", "", "postgres superuser password. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers.")
 	CmdKeeper.PersistentFlags().StringVar(&cfg.pgSUPasswordFile, "pg-su-passwordfile", "", "postgres superuser password file. Only one of --pg-su-password or --pg-su-passwordfile must be provided. Must be the same for all keepers)")
+
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.debug, "debug", false, "enable debug logging")
 
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.neverMaster, "never-master", false, "prevent keeper from being elected as master")
 	CmdKeeper.PersistentFlags().BoolVar(&cfg.neverSynchronousReplica, "never-synchronous-replica", false, "prevent keeper from being chosen as synchronous replica")
+	CmdKeeper.PersistentFlags().StringSliceVar(&cfg.pgOverrideParameters, "postgresql-parameter", []string{}, "postgresql paramerter override.")
 
 	CmdKeeper.PersistentFlags().MarkDeprecated("id", "please use --uid")
 	CmdKeeper.PersistentFlags().MarkDeprecated("debug", "use --log-level=debug instead")


### PR DESCRIPTION
ee5167c: Add a `postgresql-parameter` flag to stolon-keeper

Add a `postgresql-parameter` flag to the stolon-keeper command. This
is an optional flag that allows being passed more than once, for
example:

```
$ ./bin/stolon-keeper --postgresql-parameter guc_shared_buffer=4 --postgresql-parameter guc_checkpoint_timeout=30
```

They are captured as a string slice in the `pgOverrideParameters` member
of the `config` struct.

c688b76: Parse the pgOverrideParameters

Parse the pgOverrideParameters and add them to the `PostgresKeeper`
struct as a `map[string]string`.

9bf03f8: Override the parameters by values provided at boot

Override the values of the parameters that are explicitly passed on boot
via the `--postgresql-parameter` flag.

0e8d7af: Addressing PR review comments

- Use the common.Parameters instead of manually defining
map[string]string
- Handle edge cases with parsing the key=value parameters
- Stop parsing and return an error if any of the parameters has invalid
format
- Better naming convention for the variable
- Moving the parameters to the right position in the file
- Documenting the parsing function
