### PR TITLE
Add option to keep data in pitr init_mode

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1276,10 +1276,16 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Errorw("failed to stop pg instance", zap.Error(err))
 				return
 			}
-			if err = pgm.RemoveAllIfInitialized(); err != nil {
-				log.Errorw("failed to remove the postgres data dir", zap.Error(err))
-				return
+
+			if db.Spec.PITRConfig.KeepExistingData {
+				log.Infow("not removing existing postgres data")
+			} else {
+				if err = pgm.RemoveAllIfInitialized(); err != nil {
+					log.Errorw("failed to remove the postgres data dir", zap.Error(err))
+					return
+				}
 			}
+
 			log.Infow("executing DataRestoreCommand")
 			if err = pgm.Restore(db.Spec.PITRConfig.DataRestoreCommand); err != nil {
 				log.Errorw("failed to restore postgres database cluster", zap.Error(err))

--- a/doc/cluster_spec.md
+++ b/doc/cluster_spec.md
@@ -62,7 +62,8 @@ Some options in a running cluster specification can be changed to update the des
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-------------------------|---------|
 | dataRestoreCommand      | defines the command to execute for restoring the db cluster data. %d is replaced with the full path to the db cluster datadir. Use %% to embed an actual % character. Must return a 0 exit code only on success. | yes      | string                  |         |
 | archiveRecoverySettings | archive recovery configuration                                                                                                                                                                                   | yes      | ArchiveRecoverySettings |         |
-| recoveryTargetSettings | recovery target configuration                                                                                                                                                                                     | no       | RecoveryTargetSettings  |         |
+| recoveryTargetSettings  | recovery target configuration                                                                                                                                                                                    | no       | RecoveryTargetSettings  |         |
+| keepExistingData        | whether to keep the existing data and WAL directories, or remove them prior to executing the `dataRestoreCommand`                                                                                                | no       | bool                    | false   |
 
 #### StandbyConfig
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -162,6 +162,7 @@ type PITRConfig struct {
 	DataRestoreCommand      string                   `json:"dataRestoreCommand,omitempty"`
 	ArchiveRecoverySettings *ArchiveRecoverySettings `json:"archiveRecoverySettings,omitempty"`
 	RecoveryTargetSettings  *RecoveryTargetSettings  `json:"recoveryTargetSettings,omitempty"`
+	KeepExistingData        bool                     `json:"keepExistingData,omitempty"`
 }
 
 type ExistingConfig struct {

--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -505,6 +505,7 @@ func (p *Manager) WaitRecoveryDone(timeout time.Duration) error {
 			return err
 		}
 		if !os.IsNotExist(err) {
+			log.Infow("recovery.done file created: recovery is complete")
 			return nil
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
This option is useful if the there is already a valid PGDATA directory
on disk, in the location that the Keeper is managing, and you would like
to keep this when performing a Point In Time Recovery.

We will use this for the case of a new Stolon cluster where the keeper
instances have disks that have been created from a snapshot of a keeper
disk in a different cluster.
