### PR TITLE
Unset recovery parameters in PITR init when finished recovering

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1319,6 +1319,11 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				return
 			}
 
+			if db.Spec.Role == common.RoleMaster {
+				// Clear the recovery parameters; We want to be master
+				pgm.SetRecoveryParameters(nil)
+			}
+
 			if db.Spec.IncludeConfig {
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {


### PR DESCRIPTION
The recovery params being set will write out a ``recovery.conf`` any time the
Postgres database is reloaded, restarted or started in any way. This
will be detected by stolon as the node being on standby. This causes a
promotion to be attempted, which fails as postgres is already running
as master. Due to this, we end up in a loop where the node is
attempted to be promoted, and failures cause it to try again.

This fixes that behaviour by unsetting the recovery params after recovery has finished.