### PR TITLE
Bump version of go used by goreleaser

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ jobs:
   release:
     working_directory: /go/src/github.com/sorintlab/stolon
     docker:
-      - image: golang:1.12
+      - image: golang:1.14
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This change bumps the version of goreleaser to go 1.14.
This should fix the releaser script as it will opt into go mod by default.